### PR TITLE
add reference point for recursive installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An evil, awful, terrible, no-good library for watching objects for mutation. Do 
 ```python
 x = {1: "a", 2: "b", 3: "c"}
 
-def track_changes(obj, method, *args, **kwargs):
+def track_changes(obj, method, ref, call_args, call_kwargs):
     print(f"method: {method}, args: {args}, kwargs: {kwargs}")
 
 x = watch(x, track_changes)
@@ -24,6 +24,22 @@ x[1] = "x"
 ```
 
 `bigbrother` can also embed itself recursively in your object by passing in argument `deepstate=True`.
+
+
+## Callback
+
+```python
+def callback(obj, method, ref, call_args, call_kwargs):
+    '''Callback called when object is mutated
+
+    Args:
+        obj (Any): The object being mutated via `method`
+        method (str): The method called on the object (dunders removed)
+        ref (Any): Reference object. If callback installed recursively, `ref` will be the entrypoint
+        call_args (Tuple[Any]): Positional arguments that `method` was called with on `obj`
+        call_kwargs (Dict[Any, Any]): Keyword arguments that `method` was called with on `obj`
+    '''
+```
 
 
 ## Supported types

--- a/bigbrother/__init__.py
+++ b/bigbrother/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.1.2"
 
 from types import MethodType
-from typing import Any, Callable, Dict, List, Set, TypeVar
+from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar
 
 from .generic import _replacement_setattr, _replacement_setitem
 from .builtins import (
@@ -37,7 +37,7 @@ def _partial(watcher, obj):
     return _watcher_wrapper
 
 
-def _install_watcher(obj: T, watcher: Callable[[T, str, Any], None], recursive: bool = False) -> T:
+def _install_watcher(obj: T, watcher: Callable[[T, str, T, Tuple, Dict], None], recursive: bool = False) -> T:
     # Standard mutable types
     if isinstance(obj, List) and not isinstance(obj, _ObservedList):
         # can't mutate list so replace with watcher variant
@@ -75,7 +75,7 @@ def _install_watcher(obj: T, watcher: Callable[[T, str, Any], None], recursive: 
     return obj
 
 
-def watch(obj: T, watcher: Callable[[T, str, Any], None], deepstate: bool = False) -> T:
+def watch(obj: T, watcher: Callable[[T, str, T, Tuple, Dict], None], deepstate: bool = False) -> T:
     return _install_watcher(obj, watcher, recursive=deepstate)
 
 

--- a/bigbrother/builtins/dict.py
+++ b/bigbrother/builtins/dict.py
@@ -20,7 +20,7 @@ class _ObservedDict(Dict):
 
     def _notify_watcher(self, method, *args, **kwargs):
         if self._watcher_ready:
-            self.__class__._watcher(self, method, *args, **kwargs)
+            self.__class__._watcher(self, method, self, args, kwargs)
 
     def clear(self, *args, **kwargs):
         self._notify_watcher("clear", *args, **kwargs)
@@ -37,7 +37,7 @@ class _ObservedDict(Dict):
     def update(self, __m, **kwargs):
         other = dict(__m, **kwargs)
         if self.__class__._recursive:
-            other = self.__class__._install_watcher(other, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            other = self.__class__._install_watcher(other, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         self._notify_watcher("update", other)
         return super().update(other)
 
@@ -47,8 +47,8 @@ class _ObservedDict(Dict):
 
     def __setitem__(self, __key, __value):
         if self._recursive:
-            __key = self.__class__._install_watcher(__key, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
-            __value = self.__class__._install_watcher(__value, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            __key = self.__class__._install_watcher(__key, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
+            __value = self.__class__._install_watcher(__value, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         self._notify_watcher("setitem", __key, __value)
         return super().__setitem__(__key, __value)
 

--- a/bigbrother/builtins/list.py
+++ b/bigbrother/builtins/list.py
@@ -20,12 +20,12 @@ class _ObservedList(List):
 
     def _notify_watcher(self, method, *args, **kwargs):
         if self._watcher_ready:
-            self.__class__._watcher(self, method, *args, **kwargs)
+            self.__class__._watcher(self, method, self, args, kwargs)
 
     def append(self, __object: Any):
         self._notify_watcher("append", __object)
         if self._recursive:
-            __object = self.__class__._install_watcher(__object, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            __object = self.__class__._install_watcher(__object, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         return super().append(__object)
 
     def clear(self, *args, **kwargs):
@@ -35,13 +35,13 @@ class _ObservedList(List):
     def extend(self, __iterable):
         self._notify_watcher("extend", __iterable)
         if self._recursive:
-            __iterable = self.__class__._install_watcher(list(__iterable), watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            __iterable = self.__class__._install_watcher(list(__iterable), watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         return super().extend(__iterable)
 
     def insert(self, __key: int, __value: Any):
         self._notify_watcher("insert", __key, __value)
         if self._recursive:
-            __value = self.__class__._install_watcher(__value, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            __value = self.__class__._install_watcher(__value, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         return super().insert(__key, __value)
 
     def pop(self, *args, **kwargs):
@@ -63,7 +63,7 @@ class _ObservedList(List):
     def __setitem__(self, __key: int, __value: Any):
         self._notify_watcher("setitem", __key, __value)
         if self._recursive:
-            __value = self.__class__._install_watcher(__value, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            __value = self.__class__._install_watcher(__value, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         return super().__setitem__(__key, __value)
 
 

--- a/bigbrother/builtins/set.py
+++ b/bigbrother/builtins/set.py
@@ -22,12 +22,12 @@ class _ObservedSet(Set):
 
     def _notify_watcher(self, method, *args, **kwargs):
         if self._watcher_ready:
-            self.__class__._watcher(self, method, *args, **kwargs)
+            self.__class__._watcher(self, method, self, args, kwargs)
 
     def add(self, __element: Any):
         self._notify_watcher("add", __element)
         if self._recursive:
-            __element = self.__class__._install_watcher(__element, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            __element = self.__class__._install_watcher(__element, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         return super().add(__element)
 
     def clear(self, *args, **kwargs):
@@ -65,7 +65,7 @@ class _ObservedSet(Set):
         self._notify_watcher("update", *args)
         s = set(*args)
         if self._recursive:
-            s = self._install_watcher(s, watcher=_partial(self.__class__._watcher, self), recursive=self._recursive)
+            s = self._install_watcher(s, watcher=_partial(self.__class__._watcher, ref=self), recursive=self._recursive)
         return super().update(s)
 
     def __setattr__(self, *args, **kwargs):

--- a/bigbrother/common.py
+++ b/bigbrother/common.py
@@ -1,10 +1,5 @@
-def _partial(watcher, obj):
-    def _watcher_wrapper(*args, **kwargs):
-        if args:
-            args = args[1:]
-        if kwargs:
-            kwargs.pop("obj", None)
-            kwargs.pop("self", None)
-        return watcher(obj, *args, **kwargs)
+def _partial(watcher, ref):
+    def _watcher_wrapper(obj, method, other_ref, call_args, call_kwargs):
+        return watcher(obj, method, ref, call_args, call_kwargs)
 
     return _watcher_wrapper

--- a/bigbrother/libraries/pydantic.py
+++ b/bigbrother/libraries/pydantic.py
@@ -26,5 +26,5 @@ def _install_watcher_pydantic(obj: BaseModel, watcher: Callable[[BaseModel, str,
             #     obj.__dict__[key] = _install_watcher(value, watcher, recursive=recursive)
             ...
         # replace dict with watched version
-        object.__setattr__(obj, "__dict__", _install_watcher(obj.__dict__, watcher=_partial(watcher, obj), recursive=recursive))
+        object.__setattr__(obj, "__dict__", _install_watcher(obj.__dict__, watcher=_partial(watcher, ref=obj), recursive=recursive))
         return obj

--- a/bigbrother/tests/builtins/test_dict.py
+++ b/bigbrother/tests/builtins/test_dict.py
@@ -9,35 +9,35 @@ def a_dict():
 
 class TestDict:
     def test_dict_clear(self, a_dict):
-        instance, called = create_tester(a_dict, "clear", (), {})
+        instance, called = create_tester(instance=a_dict, method_name="clear", expected_args=(), expected_kwargs={})
         instance.clear()
         assert called[0]
         assert len(called) == 1
         assert instance == {}
 
     def test_dict_pop(self, a_dict):
-        instance, called = create_tester(a_dict, "pop", (1,), {})
+        instance, called = create_tester(instance=a_dict, method_name="pop", expected_args=(1,), expected_kwargs={})
         instance.pop(1)
         assert called[0]
         assert len(called) == 1
         assert instance == {2: "b", 3: "c"}
 
     def test_dict_popitem(self, a_dict):
-        instance, called = create_tester(a_dict, "popitem", (), {})
+        instance, called = create_tester(instance=a_dict, method_name="popitem", expected_args=(), expected_kwargs={})
         instance.popitem()
         assert called[0]
         assert len(called) == 1
         assert instance == {1: "a", 2: "b"}
 
     def test_dict_update(self, a_dict):
-        instance, called = create_tester(a_dict, "update", ({4: "d"},), {})
+        instance, called = create_tester(instance=a_dict, method_name="update", expected_args=({4: "d"},), expected_kwargs={})
         instance.update({4: "d"})
         assert called[0]
         assert len(called) == 1
         assert instance == {1: "a", 2: "b", 3: "c", 4: "d"}
 
     def test_dict___setitem__(self, a_dict):
-        instance, called = create_tester(a_dict, "setitem", (1, "x"), {})
+        instance, called = create_tester(instance=a_dict, method_name="setitem", expected_args=(1, "x"), expected_kwargs={})
         instance[1] = "x"
         assert called[0]
         assert len(called) == 1

--- a/bigbrother/tests/builtins/test_list.py
+++ b/bigbrother/tests/builtins/test_list.py
@@ -9,21 +9,21 @@ def a_list():
 
 class TestList:
     def test_list_append(self, a_list):
-        instance, called = create_tester(a_list, "append", (1,), {})
+        instance, called = create_tester(instance=a_list, method_name="append", expected_args=(1,), expected_kwargs={})
         instance.append(1)
         assert called[0]
         assert len(called) == 1
         assert instance == [1, 2, 3, 1]
 
     def test_list_clear(self, a_list):
-        instance, called = create_tester(a_list, "clear", (), {})
+        instance, called = create_tester(instance=a_list, method_name="clear", expected_args=(), expected_kwargs={})
         instance.clear()
         assert called[0]
         assert len(called) == 1
         assert instance == []
 
     def test_list_extend(self, a_list):
-        instance, called = create_tester(a_list, "extend", ([1, 2, 3],), {})
+        instance, called = create_tester(instance=a_list, method_name="extend", expected_args=([1, 2, 3],), expected_kwargs={})
         instance.extend([1, 2, 3])
         assert called[0]
         assert len(called) == 1
@@ -31,13 +31,13 @@ class TestList:
 
     def test_list_insert(self, a_list):
         instance, called = create_tester(
-            a_list,
-            "insert",
-            (
+            instance=a_list,
+            method_name="insert",
+            expected_args=(
                 0,
                 1,
             ),
-            {},
+            expected_kwargs={},
         )
         instance.insert(0, 1)
         assert called[0]
@@ -45,28 +45,28 @@ class TestList:
         assert instance == [1, 1, 2, 3]
 
     def test_list_pop(self, a_list):
-        instance, called = create_tester(a_list, "pop", (0,), {})
+        instance, called = create_tester(instance=a_list, method_name="pop", expected_args=(0,), expected_kwargs={})
         instance.pop(0)
         assert called[0]
         assert len(called) == 1
         assert instance == [2, 3]
 
     def test_list_remove(self, a_list):
-        instance, called = create_tester(a_list, "remove", (1,), {})
+        instance, called = create_tester(instance=a_list, method_name="remove", expected_args=(1,), expected_kwargs={})
         instance.remove(1)
         assert called[0]
         assert len(called) == 1
         assert instance == [2, 3]
 
     def test_list_sort(self, a_list):
-        instance, called = create_tester(a_list, "sort", (), {})
+        instance, called = create_tester(instance=a_list, method_name="sort", expected_args=(), expected_kwargs={})
         instance.sort()
         assert called[0]
         assert len(called) == 1
         assert instance == [1, 2, 3]
 
     def test_list___setitem__(self, a_list):
-        instance, called = create_tester(a_list, "setitem", (1, 4), {})
+        instance, called = create_tester(instance=a_list, method_name="setitem", expected_args=(1, 4), expected_kwargs={})
         instance[1] = 4
         assert called[0]
         assert len(called) == 1

--- a/bigbrother/tests/builtins/test_set.py
+++ b/bigbrother/tests/builtins/test_set.py
@@ -9,56 +9,56 @@ def a_set():
 
 class TestDict:
     def test_set_add(self, a_set):
-        instance, called = create_tester(a_set, "add", (4,), {})
+        instance, called = create_tester(instance=a_set, method_name="add", expected_args=(4,), expected_kwargs={})
         instance.add(4)
         assert called[0]
         assert len(called) == 1
         assert instance == {1, 2, 3, 4}
 
     def test_set_clear(self, a_set):
-        instance, called = create_tester(a_set, "clear", (), {})
+        instance, called = create_tester(instance=a_set, method_name="clear", expected_args=(), expected_kwargs={})
         instance.clear()
         assert called[0]
         assert len(called) == 1
         assert instance == set()
 
     def test_set_difference_update(self, a_set):
-        instance, called = create_tester(a_set, "difference_update", ({1, 2, 4},), {})
+        instance, called = create_tester(instance=a_set, method_name="difference_update", expected_args=({1, 2, 4},), expected_kwargs={})
         instance.difference_update({1, 2, 4})
         assert called[0]
         assert len(called) == 1
         assert instance == {3}
 
     def test_set_discard(self, a_set):
-        instance, called = create_tester(a_set, "discard", (1,), {})
+        instance, called = create_tester(instance=a_set, method_name="discard", expected_args=(1,), expected_kwargs={})
         instance.discard(1)
         assert called[0]
         assert len(called) == 1
         assert instance == {2, 3}
 
     def test_set_intersection_update(self, a_set):
-        instance, called = create_tester(a_set, "intersection_update", ({1, 3},), {})
+        instance, called = create_tester(instance=a_set, method_name="intersection_update", expected_args=({1, 3},), expected_kwargs={})
         instance.intersection_update({1, 3})
         assert called[0]
         assert len(called) == 1
         assert instance == {1, 3}
 
     def test_set_remove(self, a_set):
-        instance, called = create_tester(a_set, "remove", (1,), {})
+        instance, called = create_tester(instance=a_set, method_name="remove", expected_args=(1,), expected_kwargs={})
         instance.remove(1)
         assert called[0]
         assert len(called) == 1
         assert instance == {2, 3}
 
     def test_set_symmetric_difference_update(self, a_set):
-        instance, called = create_tester(a_set, "intersection_update", ({1, 3},), {})
+        instance, called = create_tester(instance=a_set, method_name="intersection_update", expected_args=({1, 3},), expected_kwargs={})
         instance.intersection_update({1, 3})
         assert called[0]
         assert len(called) == 1
         assert instance == {1, 3}
 
     def test_set_update(self, a_set):
-        instance, called = create_tester(a_set, "update", ({4, 5},), {})
+        instance, called = create_tester(instance=a_set, method_name="update", expected_args=({4, 5},), expected_kwargs={})
         instance.update({4, 5})
         assert called[0]
         assert len(called) == 1

--- a/bigbrother/tests/common.py
+++ b/bigbrother/tests/common.py
@@ -1,13 +1,18 @@
 from bigbrother import watch
 
 
-def create_tester(instance, method_name, expected_args, expected_kwargs):
+def create_tester(instance, method_name, expected_ref=None, expected_args=None, expected_kwargs=None):
     called = []
+    expected_ref = expected_ref or instance
+    expected_args = expected_args or ()
+    expected_kwargs = expected_kwargs or {}
 
-    def track_changes(obj, method, *args, **kwargs):
+    def track_changes(obj, method, ref, args, kwargs):
         called.append(True)
         print(f"method: {method} args: {args} kwargs: {kwargs}")
+        print(ref, expected_ref)
         assert obj == instance
+        assert ref == expected_ref
         assert method == method_name
         assert args == expected_args
         assert kwargs == expected_kwargs

--- a/bigbrother/tests/libraries/test_pydantic.py
+++ b/bigbrother/tests/libraries/test_pydantic.py
@@ -28,13 +28,13 @@ class TestPydantic:
         x = MyModel(a=my_sub_model, b=my_other_sub_model)
 
         x, called = create_tester(
-            x,
-            "setitem",
-            (
+            instance=x,
+            method_name="setitem",
+            expected_args=(
                 "d",
                 my_sub_model,
             ),
-            {},
+            expected_kwargs={},
         )
         x.d = my_sub_model
 
@@ -49,12 +49,12 @@ class TestPydantic:
 
         called = []
 
-        instance = x
+        instance = x.d
         method_name = "setitem"
         expected_args = ("x", [1])
         expected_kwargs = {}
 
-        def track_changes(obj, method, *args, **kwargs):
+        def track_changes(obj, method, ref, args, kwargs):
             called.append(True)
             print(f"method: {method} args: {args} kwargs: {kwargs}")
             assert obj == instance


### PR DESCRIPTION
add reference point for recursive installation and call on mutated object, rather than losing that information