### PR TITLE
Observe plain objects (dataclasses) via a __class__ swap

### DIFF
--- a/.copier-answers.yaml
+++ b/.copier-answers.yaml
@@ -1,7 +1,7 @@
 # Changes here will be overwritten by Copier
 _commit: 19e0124
 _src_path: https://github.com/python-project-templates/base.git
-add_docs: false
+add_docs: true
 add_extension: python
 add_wiki: false
 email: dev@1kbgz.com

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,51 @@
+name: Publish Docs
+
+on:
+  workflow_run:
+    workflows: ["Build Status"]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions-ext/python/setup@main
+
+      - name: Download dist from build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: dist-ubuntu-latest*
+          merge-multiple: true
+          path: dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+        if: github.event_name == 'workflow_run'
+
+      - name: Install from wheel
+        run: |
+          uv pip install dist/*.whl --target .
+          uv pip install yardang
+        if: github.event_name == 'workflow_run'
+
+      - name: Install from source (manual trigger)
+        run: |
+          uv pip install .[develop]
+          uv pip install yardang
+        if: github.event_name == 'workflow_dispatch'
+
+      - run: yardang build
+
+      - uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/html

--- a/bigbrother/__init__.py
+++ b/bigbrother/__init__.py
@@ -1,7 +1,6 @@
 __version__ = "0.1.3"
 
-from types import MethodType
-from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar
+from typing import Callable, Dict, List, Set, Tuple, TypeVar
 
 from .builtins import (
     _createObservedDict,
@@ -11,7 +10,7 @@ from .builtins import (
     _ObservedList,
     _ObservedSet,
 )
-from .generic import _replacement_setattr, _replacement_setitem
+from .generic import _install_watcher_object
 
 try:
     from pydantic import BaseModel
@@ -23,24 +22,12 @@ except ImportError:
 
 
 T = TypeVar("T")
+Watcher = Callable[[T, str, T, Tuple, Dict], None]
 
 
-def _partial(watcher, obj):
-    def _watcher_wrapper(*args, **kwargs):
-        if args:
-            args = args[1:]
-        if kwargs:
-            kwargs.pop("obj", None)
-            kwargs.pop("self", None)
-        return watcher(obj, *args, **kwargs)
-
-    return _watcher_wrapper
-
-
-def _install_watcher(obj: T, watcher: Callable[[T, str, T, Tuple, Dict], None], recursive: bool = False) -> T:
-    # Standard mutable types
+def _install_watcher(obj: T, watcher: Watcher, recursive: bool = False) -> T:
+    # Standard mutable containers: can't mutate their methods, so replace with an observed subclass.
     if isinstance(obj, List) and not isinstance(obj, _ObservedList):
-        # can't mutate list so replace with watcher variant
         return _createObservedList(watcher, recursive=recursive, _install_watcher=_install_watcher)(obj)
 
     if isinstance(obj, Set) and not isinstance(obj, _ObservedSet):
@@ -49,33 +36,20 @@ def _install_watcher(obj: T, watcher: Callable[[T, str, T, Tuple, Dict], None], 
     if isinstance(obj, Dict) and not isinstance(obj, _ObservedDict):
         return _createObservedDict(watcher, recursive=recursive, _install_watcher=_install_watcher)(obj)
 
-    # Library types
-    # Pydantic object
-    if BaseModel and isinstance(obj, BaseModel):
+    # Pydantic models store their fields in __dict__; observe it.
+    if BaseModel is not None and isinstance(obj, BaseModel):
         return _install_watcher_pydantic(obj=obj, watcher=watcher, recursive=recursive, _install_watcher=_install_watcher)
 
-    # Pydantic class
-    # TODO
-
-    # Others
-    try:
-        if hasattr(obj, "__setitem__"):
-            object.__setattr__(obj, "__setitem__", MethodType(_replacement_setitem, obj))
-    except AttributeError:
-        # Ignore
-        pass
-
-    try:
-        if hasattr(obj, "__setattr__"):
-            object.__setattr__(obj, "__setattr__", MethodType(_replacement_setattr, obj))
-    except AttributeError:
-        # Ignore
-        pass
-
-    return obj
+    # Generic objects (dataclasses, plain classes): swap the class for an observing subclass.
+    return _install_watcher_object(obj, watcher, recursive, _install_watcher)
 
 
-def watch(obj: T, watcher: Callable[[T, str, T, Tuple, Dict], None], deepstate: bool = False) -> T:
+def watch(obj: T, watcher: Watcher, deepstate: bool = False) -> T:
+    """Watch ``obj`` for mutation, invoking ``watcher(obj, method, ref, call_args, call_kwargs)``.
+
+    With ``deepstate=True`` the watcher is installed recursively on nested containers and objects, so
+    deep mutations (``obj.child.items.append(...)``) are reported too.
+    """
     return _install_watcher(obj, watcher, recursive=deepstate)
 
 

--- a/bigbrother/generic.py
+++ b/bigbrother/generic.py
@@ -1,8 +1,37 @@
-def _replacement_setitem(*args, **kwargs):
-    # TODO
-    ...
+"""Observe plain objects (e.g. dataclasses) that keep their state in ``__dict__``.
+
+``object.__setattr__`` writes to the instance dict at the C level, *bypassing* a dict subclass's
+``__setitem__`` — so the ``__dict__``-swap trick used for pydantic (whose ``__setattr__`` does a
+Python-level ``dict[name] = value``) does not catch attribute assignment on ordinary objects.
+Instead we swap the instance's class for a thin subclass whose ``__setattr__`` notifies the watcher.
+Objects without a ``__dict__`` (``__slots__``, e.g. ``msgspec.Struct``) can't be observed this way
+and are returned unchanged.
+"""
+
+from typing import Callable
+
+from .common import _partial
 
 
-def _replacement_setattr(*args, **kwargs):
-    # TODO
-    ...
+def _observed_class_for(cls: type, watcher: Callable) -> type:
+    base_setattr = cls.__setattr__
+
+    def _setattr(self, name, value):
+        watcher(self, "setattr", self, (name, value), {})
+        base_setattr(self, name, value)
+
+    return type(cls.__name__, (cls,), {"__setattr__": _setattr, "_bigbrother_observed": True})
+
+
+def _install_watcher_object(obj, watcher: Callable, recursive: bool, _install_watcher: Callable):
+    obj_dict = getattr(obj, "__dict__", None)
+    if not isinstance(obj_dict, dict):
+        return obj  # no __dict__ (e.g. __slots__): cannot observe
+    if getattr(type(obj), "_bigbrother_observed", False):
+        return obj  # already observed
+    object.__setattr__(obj, "__class__", _observed_class_for(type(obj), watcher))
+    if recursive:
+        for key, value in list(obj_dict.items()):
+            # write through the base setattr so installing doesn't itself notify
+            object.__setattr__(obj, key, _install_watcher(value, _partial(watcher, ref=obj), recursive=True))
+    return obj

--- a/bigbrother/tests/test_dataclass.py
+++ b/bigbrother/tests/test_dataclass.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, field
+
+from bigbrother import watch
+
+
+@dataclass
+class Sub:
+    label: str = ""
+    tags: list = field(default_factory=list)
+
+
+@dataclass
+class Obj:
+    name: str
+    on: bool = False
+    meta: Sub = field(default_factory=Sub)
+
+
+class TestDataclass:
+    def test_setattr(self):
+        o = Obj(name="x")
+        called = []
+        watch(o, lambda obj, method, ref, args, kwargs: called.append((method, args)), deepstate=True)
+        o.on = True
+        assert o.on is True
+        assert ("setattr", ("on", True)) in called
+
+    def test_nested_model_setattr(self):
+        o = Obj(name="x", meta=Sub(label="a"))
+        called = []
+        watch(o, lambda obj, method, ref, args, kwargs: called.append((method, args)), deepstate=True)
+        o.meta.label = "b"
+        assert o.meta.label == "b"
+        assert ("setattr", ("label", "b")) in called
+
+    def test_nested_list_append(self):
+        o = Obj(name="x", meta=Sub(tags=["a"]))
+        called = []
+        watch(o, lambda obj, method, ref, args, kwargs: called.append((method, args)), deepstate=True)
+        o.meta.tags.append("b")
+        assert o.meta.tags == ["a", "b"]
+        assert any(m == "append" for m, _ in called)
+
+    def test_slots_object_is_returned_unchanged(self):
+        # objects without a __dict__ cannot be observed via the __dict__ trick
+        class Slotted:
+            __slots__ = ("x",)
+
+            def __init__(self):
+                self.x = 1
+
+        s = Slotted()
+        watched = watch(s, lambda *a, **k: None, deepstate=True)
+        assert watched is s  # returned unchanged, no error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,11 @@ section-order = [
     "F401",
     "F403",
 ]
+
+[tool.yardang]
+title = "bigbrother"
+root = "README.md"
+pages = [
+    "docs/src/api.md",
+]
+use-autoapi = false


### PR DESCRIPTION
The pydantic path swaps __dict__ for an observed dict, but object.__setattr__ writes the instance dict at the C level, bypassing a dict subclass's __setitem__ -- so that trick does not catch attribute assignment on ordinary objects. Install an observing __setattr__ by swapping the instance's class for a thin subclass instead (generic.py: _install_watcher_object); objects without a __dict__ (__slots__) are returned unchanged. Drop the dead _replacement_setattr / _replacement_setitem stubs and add dataclass tests.

Also add yardang docs config and a docs CI workflow.