### PR TITLE
Handle unsupported watcher targets

### DIFF
--- a/bigbrother/__init__.py
+++ b/bigbrother/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.1.4"
 
+from enum import Enum
 from typing import Callable, Dict, List, Set, Tuple, TypeVar
 
 from .builtins import (
@@ -35,6 +36,9 @@ def _install_watcher(obj: T, watcher: Watcher, recursive: bool = False) -> T:
 
     if isinstance(obj, Dict) and not isinstance(obj, _ObservedDict):
         return _createObservedDict(watcher, recursive=recursive, _install_watcher=_install_watcher)(obj)
+
+    if isinstance(obj, Enum):
+        return obj
 
     # Pydantic models store their fields in __dict__; observe it.
     if BaseModel is not None and isinstance(obj, BaseModel):

--- a/bigbrother/generic.py
+++ b/bigbrother/generic.py
@@ -4,8 +4,8 @@
 ``__setitem__`` — so the ``__dict__``-swap trick used for pydantic (whose ``__setattr__`` does a
 Python-level ``dict[name] = value``) does not catch attribute assignment on ordinary objects.
 Instead we swap the instance's class for a thin subclass whose ``__setattr__`` notifies the watcher.
-Objects without a ``__dict__`` (``__slots__``, e.g. ``msgspec.Struct``) can't be observed this way
-and are returned unchanged.
+Objects without a ``__dict__`` (``__slots__``, e.g. ``msgspec.Struct``), or objects that reject
+``__class__`` assignment, can't be observed this way and are returned unchanged.
 """
 
 from typing import Callable
@@ -29,7 +29,10 @@ def _install_watcher_object(obj, watcher: Callable, recursive: bool, _install_wa
         return obj  # no __dict__ (e.g. __slots__): cannot observe
     if getattr(type(obj), "_bigbrother_observed", False):
         return obj  # already observed
-    object.__setattr__(obj, "__class__", _observed_class_for(type(obj), watcher))
+    try:
+        object.__setattr__(obj, "__class__", _observed_class_for(type(obj), watcher))
+    except TypeError:
+        return obj
     if recursive:
         for key, value in list(obj_dict.items()):
             # write through the base setattr so installing doesn't itself notify

--- a/bigbrother/tests/test_enum.py
+++ b/bigbrother/tests/test_enum.py
@@ -1,0 +1,27 @@
+from enum import Enum
+
+from bigbrother import watch
+
+
+class Color(Enum):
+    RED = "red"
+
+
+def test_enum_is_returned_unchanged():
+    called = []
+
+    watched = watch(Color.RED, lambda *args: called.append(args), deepstate=True)
+
+    assert watched is Color.RED
+    assert called == []
+
+
+def test_deepstate_leaves_nested_enum_unchanged():
+    called = []
+
+    watched = watch({"color": Color.RED}, lambda *args: called.append(args), deepstate=True)
+
+    assert watched["color"] is Color.RED
+    watched["status"] = Color.RED
+    assert watched["status"] is Color.RED
+    assert len(called) == 1

--- a/bigbrother/tests/test_generic.py
+++ b/bigbrother/tests/test_generic.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from bigbrother import watch
+
+
+def sample_function():
+    pass
+
+
+def test_objects_that_reject_class_assignment_are_returned_unchanged():
+    for obj in (SimpleNamespace(x=1), Exception("x"), sample_function):
+        called = []
+
+        watched = watch(obj, lambda *args: called.append(args), deepstate=True)
+
+        assert watched is obj
+        assert called == []
+
+
+def test_deepstate_tracks_parent_mutation_with_unsupported_value():
+    called = []
+    error = Exception("x")
+
+    watched = watch({}, lambda obj, method, ref, args, kwargs: called.append((method, args)), deepstate=True)
+    watched["error"] = error
+
+    assert watched["error"] is error
+    assert called == [("setitem", ("error", error))]


### PR DESCRIPTION
Return Enum members unchanged instead of trying to observe them directly. Return generic objects unchanged when Python rejects subclass creation or __class__ assignment, while preserving parent mutation tracking.
